### PR TITLE
Preserve imported overrides

### DIFF
--- a/src/renderer/store/rootReducer/overrides/epics.ts
+++ b/src/renderer/store/rootReducer/overrides/epics.ts
@@ -60,13 +60,17 @@ export const exportHotkeysEpic = (
         const overrides = overridesSelector(state);
         const ws = fs.createWriteStream(filePath);
         for (const [abilityId, override] of Object.entries(overrides)) {
-          ws.write(`[${abilityId}]\n`);
+          const keyValues = override.additionalOverrides;
           if (override.hotkey) {
-            ws.write(`Hotkey=${override.hotkey}\n`);
-            ws.write(`Researchhotkey=${override.hotkey}\n`);
+            keyValues['Hotkey'] = override.hotkey;
+            keyValues['Researchhotkey'] = override.hotkey;
           }
           if (override.unhotKey) {
-            ws.write(`Unhotkey=${override.unhotKey}\n`);
+            keyValues['Unhotkey'] = override.unhotKey;
+          }
+          ws.write(`[${abilityId}]\n`);
+          for (const [k, v] of Object.entries(keyValues)) {
+            ws.write(`${k}=${v}\n`);
           }
           ws.write(`\n`);
         }

--- a/src/renderer/store/rootReducer/overrides/reducer.ts
+++ b/src/renderer/store/rootReducer/overrides/reducer.ts
@@ -4,6 +4,11 @@ import produce from 'immer';
 export interface Override {
   hotkey?: string;
   unhotKey?: string;
+  additionalOverrides: Record<string, string>;
+}
+
+function NewOverride(): Override {
+  return { additionalOverrides: {} };
 }
 
 export const initialState = {} as Record<string, Override>;
@@ -14,7 +19,7 @@ export const reducer = produce((draft: State, action: fromActions.Actions) => {
     case fromActions.OVERRIDE_HOTKEY: {
       const { abilityId, hotkey } = action.payload;
       if (!draft[abilityId]) {
-        draft[abilityId] = {};
+        draft[abilityId] = NewOverride();
       }
       draft[abilityId].hotkey = hotkey.toUpperCase();
       break;
@@ -23,7 +28,7 @@ export const reducer = produce((draft: State, action: fromActions.Actions) => {
     case fromActions.OVERRIDE_UNHOTKEY: {
       const { abilityId, unhotkey } = action.payload;
       if (!draft[abilityId]) {
-        draft[abilityId] = {};
+        draft[abilityId] = NewOverride();
       }
       draft[abilityId].unhotKey = unhotkey.toUpperCase();
       break;
@@ -38,7 +43,7 @@ export const reducer = produce((draft: State, action: fromActions.Actions) => {
       for (const hotkeyOverride of hotkeyOverrides) {
         const abilityId = hotkeyOverride.ability_id;
         if (!draft[abilityId]) {
-          draft[abilityId] = {};
+          draft[abilityId] = NewOverride();
         }
 
         for (const override of hotkeyOverride.overrides) {
@@ -46,9 +51,10 @@ export const reducer = produce((draft: State, action: fromActions.Actions) => {
           const value = override[1];
           if (key === 'Hotkey') {
             draft[abilityId].hotkey = value.toUpperCase();
-          }
-          if (key === 'Unhotkey') {
+          } else if (key === 'Unhotkey') {
             draft[abilityId].unhotKey = value.toUpperCase();
+          } else {
+            draft[abilityId].additionalOverrides[key] = value;
           }
         }
       }


### PR DESCRIPTION
Ensure key values from an import hotkeys file are preserved, rather than thrown out if it is not used by the application